### PR TITLE
feat: layout e comportamento da página de perfil de usuário

### DIFF
--- a/app/lib/routes/app_pages.dart
+++ b/app/lib/routes/app_pages.dart
@@ -1,6 +1,8 @@
 import 'package:get/get.dart';
+
 import 'package:pet_profile/pages/pet_register_page.dart';
 import 'package:user_profile/pages/login_page.dart';
+import 'package:user_profile/pages/profile_page.dart';
 import 'package:user_profile/pages/register_page.dart';
 import 'package:user_profile/pages/status_page.dart';
 
@@ -30,6 +32,10 @@ class AppPages {
     GetPage(
       name: Routes.petRegisterRoute,
       page: () => PetRegisterPage(),
+    ),
+    GetPage(
+      name: Routes.userProfile,
+      page: () => ProfilePage(),
     ),
   ];
 }

--- a/app/lib/routes/app_routes.dart
+++ b/app/lib/routes/app_routes.dart
@@ -4,4 +4,5 @@ abstract class Routes {
   static const registerRoute = "/register";
   static const statusRoute = "/status";
   static const petRegisterRoute = "/pet_register";
+  static const userProfile = "/user_profile";
 }

--- a/modules/pet_profile/lib/pages/pet_register_page.dart
+++ b/modules/pet_profile/lib/pages/pet_register_page.dart
@@ -53,22 +53,30 @@ class _PetRegisterPageState extends State<PetRegisterPage> {
             'Informações Gerais',
             style: TextStyle(fontSize: 16),
           ),
-          FormInputBox(hintText: 'Nome', controller: _nameController),
-          FormDropDownInput(
-            child: buildDropDownItem(
-                currentValue: speciesCurrentValue,
-                items: species,
-                hintText: 'Espécie'),
+          FormInputBox(
+            hintText: 'Nome',
+            controller: _nameController,
           ),
           FormDropDownInput(
             child: buildDropDownItem(
-                currentValue: genderCurrentValue,
-                items: gender,
-                hintText: 'Sexo'),
+              currentValue: speciesCurrentValue,
+              items: species,
+              hintText: 'Espécie',
+            ),
           ),
           FormDropDownInput(
             child: buildDropDownItem(
-                currentValue: sizeCurrentValue, items: size, hintText: 'Porte'),
+              currentValue: genderCurrentValue,
+              items: gender,
+              hintText: 'Sexo',
+            ),
+          ),
+          FormDropDownInput(
+            child: buildDropDownItem(
+              currentValue: sizeCurrentValue,
+              items: size,
+              hintText: 'Porte',
+            ),
           ),
           FormDropDownInput(
             child: buildDropDownItem(
@@ -78,23 +86,40 @@ class _PetRegisterPageState extends State<PetRegisterPage> {
           ),
           FormDropDownInput(
             child: buildDropDownItem(
-                currentValue: neuteredCurrentValue,
-                items: neutered,
-                hintText: 'Castrado(a)?'),
+              currentValue: neuteredCurrentValue,
+              items: neutered,
+              hintText: 'Castrado(a)?',
+            ),
           ),
           FormDropDownInput(
             child: buildDropDownItem(
-                currentValue: specialNeedsCurrentValue,
-                items: specialNeeds,
-                hintText: 'Necessidades Especiais?'),
+              currentValue: specialNeedsCurrentValue,
+              items: specialNeeds,
+              hintText: 'Necessidades Especiais?',
+            ),
           ),
           FormInputBox(
-              hintText: 'Localização', controller: _locationController),
-          FormInputBox(hintText: 'Raça', controller: _breedController),
-          FormInputBox(hintText: 'Idade', controller: _ageController),
-          FormInputBox(hintText: 'Peso', controller: _weightController),
+            hintText: 'Localização',
+            controller: _locationController,
+          ),
           FormInputBox(
-              hintText: 'Descrição', controller: _descriptionController),
+            hintText: 'Raça',
+            controller: _breedController,
+          ),
+          FormInputBox(
+            hintText: 'Idade',
+            controller: _ageController,
+            textInputType: TextInputType.number,
+          ),
+          FormInputBox(
+            hintText: 'Peso',
+            controller: _weightController,
+            textInputType: TextInputType.number,
+          ),
+          FormInputBox(
+            hintText: 'Descrição',
+            controller: _descriptionController,
+          ),
         ],
       ),
     );

--- a/modules/theme/lib/form_components/generic_form_input.dart
+++ b/modules/theme/lib/form_components/generic_form_input.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:get/get.dart';
 import 'package:theme/layout/app_config.dart';
 
 class FormInputBox extends StatelessWidget {
@@ -15,6 +16,8 @@ class FormInputBox extends StatelessWidget {
     this.horizontalAxisAlignment = MainAxisAlignment.start,
     EdgeInsets? padding,
     double? borderRadius,
+    this.textInputType,
+    this.enable,
   })  : backgroundColor = backgroundColor ?? AppColors.editTextColor,
         textColor = textColor ?? AppColors.white,
         borderRadius = borderRadius ?? AppRadius.editTextRadius,
@@ -30,6 +33,8 @@ class FormInputBox extends StatelessWidget {
   final List<TextInputFormatter>? inputFormatters;
   final TextEditingController controller;
   final String? Function(String?)? validator;
+  final bool? enable;
+  final TextInputType? textInputType;
 
   @override
   Widget build(BuildContext context) {
@@ -44,6 +49,8 @@ class FormInputBox extends StatelessWidget {
           Padding(
             padding: padding,
             child: TextFormField(
+              keyboardType: textInputType,
+              enabled: enable ?? true,
               cursorColor: AppColors.buttonColor,
               decoration: InputDecoration(
                 border: InputBorder.none,

--- a/modules/theme/lib/form_components/password_input.dart
+++ b/modules/theme/lib/form_components/password_input.dart
@@ -3,18 +3,19 @@ import 'package:flutter/services.dart';
 import 'package:theme/layout/app_config.dart';
 
 class FormInputBoxPassword extends StatefulWidget {
-  const FormInputBoxPassword({
-    Key? key,
-    required this.hintText,
-    required this.controller,
-    this.inputFormatters,
-    this.validator,
-    Color? backgroundColor,
-    Color? textColor,
-    this.horizontalAxisAlignment = MainAxisAlignment.start,
-    EdgeInsets? padding,
-    double? borderRadius,
-  })  : backgroundColor = backgroundColor ?? AppColors.editTextColor,
+  const FormInputBoxPassword(
+      {Key? key,
+      required this.hintText,
+      required this.controller,
+      this.inputFormatters,
+      this.validator,
+      Color? backgroundColor,
+      Color? textColor,
+      this.horizontalAxisAlignment = MainAxisAlignment.start,
+      EdgeInsets? padding,
+      double? borderRadius,
+      this.inputEnabled})
+      : backgroundColor = backgroundColor ?? AppColors.editTextColor,
         textColor = textColor ?? AppColors.white,
         // borderRadius = borderRadius ?? AppRadius().editTextRadius,
         borderRadius = borderRadius ?? 10.0,
@@ -30,6 +31,7 @@ class FormInputBoxPassword extends StatefulWidget {
   final List<TextInputFormatter>? inputFormatters;
   final TextEditingController controller;
   final String? Function(String?)? validator;
+  final bool? inputEnabled;
 
   @override
   State<FormInputBoxPassword> createState() => _FormInputBoxPasswordState();
@@ -57,6 +59,7 @@ class _FormInputBoxPasswordState extends State<FormInputBoxPassword> {
           Padding(
             padding: widget.padding,
             child: TextFormField(
+              enabled: widget.inputEnabled ?? true,
               cursorColor: AppColors.buttonColor,
               decoration: InputDecoration(
                   border: InputBorder.none,

--- a/modules/user_profile/lib/pages/profile_page.dart
+++ b/modules/user_profile/lib/pages/profile_page.dart
@@ -1,0 +1,169 @@
+import 'package:extensions/extensions.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:mask_text_input_formatter/mask_text_input_formatter.dart';
+import 'package:matchpet/routes/app_routes.dart';
+import 'package:theme/export_theme.dart';
+import 'package:user_profile/controller/user_controller.dart';
+import 'package:user_profile/model/token.dart';
+
+class ProfilePage extends StatefulWidget {
+  const ProfilePage({Key? key}) : super(key: key);
+
+  @override
+  State<ProfilePage> createState() => _ProfilePage();
+}
+
+class _ProfilePage extends State<ProfilePage> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _phoneController = TextEditingController();
+  final _emailController = TextEditingController();
+  final _pwController = TextEditingController();
+  final _pwConfirmationController = TextEditingController();
+  Rx<bool> inputEnabled = Rx<bool>(false);
+
+  @override
+  Widget build(BuildContext context) {
+    var phoneFormatter = MaskTextInputFormatter(
+        mask: '(##) #####-####',
+        filter: {'#': RegExp(r'[0-9]')},
+        type: MaskAutoCompletionType.lazy);
+
+    return Obx(() {
+      return Scaffold(
+        appBar: GenericAppBar(title: 'Meu Perfil', appBar: AppBar()),
+        backgroundColor: AppColors.primaryColor,
+        body: SingleChildScrollView(
+          child: Column(
+            children: [
+              Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 25, vertical: 15),
+                child: Column(
+                  children: [
+                    const SizedBox(height: 10),
+                    Form(
+                      key: _formKey,
+                      child: Wrap(
+                        runSpacing: 22,
+                        children: <Widget>[
+                          Center(
+                              child: ImageInput(
+                                  ontapIcon: () {},
+                                  placeHolderPath: AppSvgs.userIcon)),
+                          const SizedBox(height: 20),
+                          const Text(
+                            'Informações pessoais',
+                            style: TextStyle(fontSize: 16),
+                          ),
+                          FormInputBox(
+                            backgroundColor: inputEnabled.value
+                                ? null
+                                : Colors.grey.withOpacity(0.5),
+                            enable: inputEnabled.value,
+                            hintText: 'Nome Completo',
+                            controller: _nameController,
+                            validator: (String? val) {
+                              if (!val!.isValidName) {
+                                return "Insira o nome completo.";
+                              }
+                              return null;
+                            },
+                          ),
+                          FormInputBox(
+                            textInputType: TextInputType.phone,
+                            backgroundColor: inputEnabled.value
+                                ? null
+                                : Colors.grey.withOpacity(0.5),
+                            enable: inputEnabled.value,
+                            hintText: 'Telefone',
+                            controller: _phoneController,
+                            inputFormatters: [phoneFormatter],
+                            validator: (String? val) {
+                              if (!val!.isValidPhone) {
+                                return "Insira um número de telefone celular válido.";
+                              }
+                              return null;
+                            },
+                          ),
+                          FormInputBox(
+                            textInputType: TextInputType.emailAddress,
+                            backgroundColor: inputEnabled.value
+                                ? null
+                                : Colors.grey.withOpacity(0.5),
+                            enable: inputEnabled.value,
+                            hintText: 'E-mail',
+                            controller: _emailController,
+                            validator: (String? val) {
+                              if (!val!.isValidEmail) {
+                                return "Insira um e-mail válido";
+                              }
+                              return null;
+                            },
+                          ),
+                          FormInputBoxPassword(
+                            backgroundColor: inputEnabled.value
+                                ? null
+                                : Colors.grey.withOpacity(0.5),
+                            inputEnabled: inputEnabled.value,
+                            hintText: 'Senha',
+                            controller: _pwController,
+                            validator: (String? val) {
+                              if (!val!.isValidPassword) {
+                                return "Senha deve possuir ao menos 8 caracteres.";
+                              }
+                              return null;
+                            },
+                          ),
+                          FormInputBoxPassword(
+                            backgroundColor: inputEnabled.value
+                                ? null
+                                : Colors.grey.withOpacity(0.5),
+                            inputEnabled: inputEnabled.value,
+                            hintText: 'Confirme sua senha',
+                            controller: _pwConfirmationController,
+                            validator: (String? val) {
+                              if (!val!.isValidPassword) {
+                                return "Confirmação de senha não é válida.";
+                              }
+                              return null;
+                            },
+                          ),
+                          Center(
+                            child: inputEnabled.value
+                                ? PrimaryButton(
+                                    onTap: () => {inputEnabled.value = false},
+                                    text: 'Salvar',
+                                  )
+                                : Row(
+                                    mainAxisAlignment:
+                                        MainAxisAlignment.spaceBetween,
+                                    children: [
+                                      PrimaryButton(
+                                          width: 170,
+                                          onTap: () =>
+                                              {inputEnabled.value = true},
+                                          text: 'Editar'),
+                                      PrimaryButton(
+                                          width: 170,
+                                          onTap: () =>
+                                              {inputEnabled.value = true},
+                                          text: 'Excluir'),
+                                    ],
+                                  ),
+                          ),
+                          const SizedBox(height: 10),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    });
+  }
+}

--- a/modules/user_profile/lib/pages/status_page.dart
+++ b/modules/user_profile/lib/pages/status_page.dart
@@ -27,24 +27,26 @@ class StatusPage extends StatelessWidget {
           children: [
             const SizedBox(height: 200),
             Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: FutureBuilder<User?>(
-                    future: _getUser(),
-                    builder: ((context, snapshot) {
-                      String msg =
-                          'Vish! Algo deu errado. \n\n  Chamaremos os universitários!';
-                      if (snapshot.hasData) {
-                        User? user = snapshot.data;
-                        if (user != null) {
-                          msg =
-                              "Usuário ${user.name} conectado com sucesso - email: ${user.email}";
-                        }
-                      }
-                      return Text(msg,
-                          textAlign: TextAlign.center,
-                          style: const TextStyle(
-                              fontSize: 28, color: AppColors.buttonColor));
-                    }))),
+              padding: const EdgeInsets.all(8.0),
+              child: FutureBuilder<User?>(
+                future: _getUser(),
+                builder: ((context, snapshot) {
+                  String msg =
+                      'Vish! Algo deu errado. \n\n  Chamaremos os universitários!';
+                  if (snapshot.hasData) {
+                    User? user = snapshot.data;
+                    if (user != null) {
+                      msg =
+                          "Usuário ${user.name} conectado com sucesso - email: ${user.email}";
+                    }
+                  }
+                  return Text(msg,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                          fontSize: 20, color: AppColors.buttonColor));
+                }),
+              ),
+            ),
             const SizedBox(height: 50),
             Center(
               child: PrimaryButton(
@@ -61,6 +63,12 @@ class StatusPage extends StatelessWidget {
               child: PrimaryButton(
                   onTap: () => {Get.to(PetListPage(petList: []))},
                   text: 'Ver Pets'),
+            ),
+            const SizedBox(height: 30),
+            Center(
+              child: PrimaryButton(
+                  onTap: () => {Get.toNamed(Routes.userProfile)},
+                  text: 'Ver meu Perfil'),
             ),
           ],
         ),


### PR DESCRIPTION
### O que foi feito:

* Layout da página de perfil de usuário, inicialmente apenas como visualização. Campos para edição iniciam desabilitados.
* Comportamento dos botões para liberar a edição dos campos e mudar a construção do botão
* Adicionado condicional para setar o typo de teclado conforme o campo.


https://user-images.githubusercontent.com/66281304/201993889-24ae5057-2adc-4c33-b414-003e01757c97.mp4

